### PR TITLE
Add llms.txt generation and copy as markdown button

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -1,6 +1,7 @@
 import {themes as prismThemes} from 'prism-react-renderer';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
+import llmTxtPlugin from './plugins/llm-txt-plugin';
 
 const config: Config = {
   title: 'Documentation for Leaflet-Geoman',
@@ -55,6 +56,8 @@ const config: Config = {
       } satisfies Preset.Options,
     ],
   ],
+
+  plugins: [llmTxtPlugin],
 
   themeConfig: {
     // Replace with your project's social card

--- a/plugins/llm-txt-plugin.ts
+++ b/plugins/llm-txt-plugin.ts
@@ -1,0 +1,141 @@
+import type { Plugin, LoadContext } from '@docusaurus/types';
+import * as fs from 'fs';
+import * as path from 'path';
+
+interface DocContent {
+  title: string;
+  path: string;
+  content: string;
+}
+
+function extractFrontmatter(content: string): { title: string; body: string } {
+  const frontmatterRegex = /^---\s*\n([\s\S]*?)\n---\s*\n/;
+  const match = content.match(frontmatterRegex);
+
+  let title = '';
+  let body = content;
+
+  if (match) {
+    const frontmatter = match[1];
+    const titleMatch = frontmatter.match(/title:\s*["']?([^"'\n]+)["']?/);
+    if (titleMatch) {
+      title = titleMatch[1].trim();
+    }
+    body = content.slice(match[0].length);
+  }
+
+  if (!title) {
+    const headingMatch = body.match(/^#\s+(.+)$/m);
+    if (headingMatch) {
+      title = headingMatch[1].trim();
+    }
+  }
+
+  return { title, body };
+}
+
+function stripMdxComponents(content: string): string {
+  let cleaned = content.replace(/^import\s+.*$/gm, '');
+
+  cleaned = cleaned.replace(/<[A-Z][a-zA-Z]*[^>]*\/>/g, '');
+  cleaned = cleaned.replace(/<[A-Z][a-zA-Z]*[^>]*>[\s\S]*?<\/[A-Z][a-zA-Z]*>/g, '');
+
+  cleaned = cleaned.replace(/\n{3,}/g, '\n\n');
+
+  return cleaned.trim();
+}
+
+function getAllMarkdownFiles(dir: string, baseDir: string = dir): DocContent[] {
+  const docs: DocContent[] = [];
+
+  if (!fs.existsSync(dir)) {
+    return docs;
+  }
+
+  const items = fs.readdirSync(dir);
+
+  for (const item of items) {
+    const fullPath = path.join(dir, item);
+    const stat = fs.statSync(fullPath);
+
+    if (stat.isDirectory()) {
+      docs.push(...getAllMarkdownFiles(fullPath, baseDir));
+    } else if (item.endsWith('.md') || item.endsWith('.mdx')) {
+      const content = fs.readFileSync(fullPath, 'utf-8');
+      const { title, body } = extractFrontmatter(content);
+      const cleanedContent = stripMdxComponents(body);
+
+      const relativePath = path.relative(baseDir, fullPath);
+      const urlPath = relativePath
+        .replace(/\\/g, '/')
+        .replace(/\.mdx?$/, '')
+        .replace(/index$/, '')
+        .replace(/^\d+-/, '')
+        .replace(/\/\d+-/g, '/');
+
+      docs.push({
+        title: title || path.basename(item, path.extname(item)),
+        path: urlPath,
+        content: cleanedContent,
+      });
+    }
+  }
+
+  return docs;
+}
+
+function generateLlmTxt(docs: DocContent[], siteUrl: string, baseUrl: string): string {
+  const header = `# Leaflet-Geoman Documentation
+
+> This file contains all documentation in a format optimized for LLMs.
+> Source: ${siteUrl}${baseUrl}
+
+## Table of Contents
+
+${docs.map((doc, i) => `${i + 1}. [${doc.title}](#${doc.title.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')})`).join('\n')}
+
+---
+
+`;
+
+  const content = docs
+    .map((doc) => {
+      return `## ${doc.title}
+
+**URL:** ${siteUrl}${baseUrl}/${doc.path}
+
+${doc.content}
+
+---
+`;
+    })
+    .join('\n');
+
+  return header + content;
+}
+
+export default function llmTxtPlugin(context: LoadContext): Plugin {
+  const generateAndSaveLlmTxt = (outputDir: string) => {
+    const docsDir = path.join(context.siteDir, 'docs');
+    const docs = getAllMarkdownFiles(docsDir);
+
+    docs.sort((a, b) => a.path.localeCompare(b.path));
+
+    const llmTxt = generateLlmTxt(
+      docs,
+      context.siteConfig.url,
+      context.siteConfig.baseUrl.replace(/\/$/, '')
+    );
+
+    const outputPath = path.join(outputDir, 'llms.txt');
+    fs.writeFileSync(outputPath, llmTxt, 'utf-8');
+    console.log(`Generated llms.txt at ${outputPath}`);
+  };
+
+  return {
+    name: 'llm-txt-plugin',
+    async postBuild(props) {
+      generateAndSaveLlmTxt(props.outDir);
+    },
+  };
+}

--- a/src/components/CopyAsMarkdown/index.tsx
+++ b/src/components/CopyAsMarkdown/index.tsx
@@ -1,0 +1,86 @@
+import React, { useState, useCallback } from 'react';
+import styles from './styles.module.css';
+
+interface CopyAsMarkdownProps {
+  className?: string;
+}
+
+export default function CopyAsMarkdown({ className }: CopyAsMarkdownProps): JSX.Element {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      // Get the current page's markdown source URL
+      const editUrl = document.querySelector<HTMLAnchorElement>('a[href*="github.com"][href*="/edit/"]');
+
+      if (editUrl) {
+        // Convert edit URL to raw content URL
+        const rawUrl = editUrl.href
+          .replace('github.com', 'raw.githubusercontent.com')
+          .replace('/edit/', '/');
+
+        const response = await fetch(rawUrl);
+        if (response.ok) {
+          const markdown = await response.text();
+          await navigator.clipboard.writeText(markdown);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 2000);
+          return;
+        }
+      }
+
+      // Fallback: convert visible content to markdown-like format
+      const article = document.querySelector('article');
+      if (article) {
+        const title = document.querySelector('h1')?.textContent || '';
+        const content = article.innerText;
+        const markdown = `# ${title}\n\n${content}`;
+        await navigator.clipboard.writeText(markdown);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }
+    } catch (err) {
+      console.error('Failed to copy:', err);
+    }
+  }, []);
+
+  return (
+    <button
+      className={`${styles.copyButton} ${className || ''}`}
+      onClick={handleCopy}
+      title="Copy page content as Markdown"
+      aria-label="Copy page content as Markdown"
+    >
+      {copied ? (
+        <>
+          <CheckIcon />
+          <span>Copied!</span>
+        </>
+      ) : (
+        <>
+          <CopyIcon />
+          <span>Copy as Markdown</span>
+        </>
+      )}
+    </button>
+  );
+}
+
+function CopyIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+         strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+         strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}

--- a/src/components/CopyAsMarkdown/styles.module.css
+++ b/src/components/CopyAsMarkdown/styles.module.css
@@ -1,0 +1,27 @@
+.copyButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--ifm-color-primary);
+  background: transparent;
+  border: 1px solid var(--ifm-color-primary);
+  border-radius: 0.375rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.copyButton:hover {
+  background: var(--ifm-color-primary);
+  color: white;
+}
+
+.copyButton:active {
+  transform: scale(0.98);
+}
+
+.copyButton svg {
+  flex-shrink: 0;
+}

--- a/src/theme/DocBreadcrumbs/index.tsx
+++ b/src/theme/DocBreadcrumbs/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import DocBreadcrumbs from '@theme-original/DocBreadcrumbs';
+import type DocBreadcrumbsType from '@theme/DocBreadcrumbs';
+import type { WrapperProps } from '@docusaurus/types';
+import CopyAsMarkdown from '@site/src/components/CopyAsMarkdown';
+import styles from './styles.module.css';
+
+type Props = WrapperProps<typeof DocBreadcrumbsType>;
+
+export default function DocBreadcrumbsWrapper(props: Props): JSX.Element {
+  return (
+    <div className={styles.breadcrumbsRow}>
+      <DocBreadcrumbs {...props} />
+      <CopyAsMarkdown />
+    </div>
+  );
+}

--- a/src/theme/DocBreadcrumbs/styles.module.css
+++ b/src/theme/DocBreadcrumbs/styles.module.css
@@ -1,0 +1,11 @@
+.breadcrumbsRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.breadcrumbsRow > nav {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
## Summary
- Add plugin to generate `llms.txt` during build containing all documentation optimized for LLM consumption
- Add "Copy as Markdown" button to breadcrumbs for easy content copying from any doc page
- Create DocBreadcrumbs theme wrapper to include the copy button alongside navigation

## Test plan
- [x] Verify `llms.txt` is generated during `npm run build`
- [x] Verify content is accessible at `/docs/leaflet/llms.txt` after deployment
- [x] Test Copy as Markdown button functionality on documentation pages