### PR TITLE
Make documentation LLM-friendly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 # Generated files
 .docusaurus
 .cache-loader
+/static/llms.txt
+/static/llms-full.txt
 
 # Misc
 .DS_Store

--- a/docs/12.utils.md
+++ b/docs/12.utils.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 12
 title: Utils
+description: "Utility methods for coordinate calculations, circle-to-polygon conversion, layer discovery, and measurement functions."
 ---
 ### Utils
 

--- a/docs/13.screenshots.md
+++ b/docs/13.screenshots.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 12
 title: Screenshots
+description: "Capture map screenshots with the Leaflet-Geoman Pro Screenshot plugin. Covers installation, caption options, and screenshot events."
 ---
 # Adding Leaflet-Geoman-Pro-Screenshot Plugin
 

--- a/docs/14.lazy-loading.md
+++ b/docs/14.lazy-loading.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 12
 title: Lazy Loading
+description: "Defer loading Leaflet-Geoman for performance. Use L.PM.reInitLayer to attach Geoman to an already-initialized map."
 ---
 ### Lazy Loading
 

--- a/docs/16.keyboard.md
+++ b/docs/16.keyboard.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 16
 title: Keyboard
+description: "Keyboard event handling in Leaflet-Geoman. Access key states, listen for key events, and configure keyboard shortcuts."
 ---
 ### Keyboard
 

--- a/docs/changelog/free.md
+++ b/docs/changelog/free.md
@@ -1,5 +1,6 @@
 ---
 title: Leaflet-Geoman Free
+description: "Release history and changelog for Leaflet-Geoman Free version."
 ---
 
 ## [2.19.0] - 2025-12-12

--- a/docs/changelog/pro.md
+++ b/docs/changelog/pro.md
@@ -1,5 +1,6 @@
 ---
 title: Leaflet-Geoman Pro ⭐
+description: "Release history and changelog for Leaflet-Geoman Pro version."
 ---
 ## v2.15.0 Adding `pm:error` event
 April 2025

--- a/docs/customize/2.language.md
+++ b/docs/customize/2.language.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 2
 title: Customize Language
+description: "Change the language of Leaflet-Geoman UI text. Supports 27 languages with custom translation override capability."
 ---
 #### Customize Language
 

--- a/docs/customize/4.style.md
+++ b/docs/customize/4.style.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 4
 title: Customize Style
+description: "Customize the visual style of drawn layers using Leaflet path options. Set styles globally or per drawing mode."
 ---
 #### Customize Style
 

--- a/docs/customize/6.toolbar.md
+++ b/docs/customize/6.toolbar.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 6
 title: Toolbar
+description: "Customize toolbar layout, button order, block positions, and create custom controls with configurable actions."
 ---
 ### Toolbar
 

--- a/docs/getting-started/free-version.md
+++ b/docs/getting-started/free-version.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 title: "Free Version"
+description: "Install and set up Leaflet-Geoman Free via npm or CDN. Covers initialization, layer exclusion with pmIgnore, and Opt-In mode."
 ---
 ## Installation
 

--- a/docs/getting-started/pro-version.md
+++ b/docs/getting-started/pro-version.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 2
 title: "Pro Version"
+description: "Install Leaflet-Geoman Pro via npm with license key authentication. Covers registry setup, initialization, and Opt-In mode."
 ---
 ## Installation
 

--- a/docs/layer-groups.md
+++ b/docs/layer-groups.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 7
 title: "Layer Groups"
+description: "Work with FeatureGroup and GeoJSON LayerGroups in Leaflet-Geoman. Methods for enabling, disabling, and managing grouped layers."
 ---
 ### LayerGroup
 

--- a/docs/modes/0.index.md
+++ b/docs/modes/0.index.md
@@ -1,3 +1,8 @@
+---
+title: "Modes"
+description: "Overview of Leaflet-Geoman editing modes. Only one mode can be active at a time. Enable modes programmatically or via the toolbar."
+---
+
 # Modes
 
 Leaflet-Geoman has different modes.

--- a/docs/modes/1.draw-mode.mdx
+++ b/docs/modes/1.draw-mode.mdx
@@ -1,5 +1,6 @@
 ---
 title: Draw Mode
+description: "Draw markers, polygons, polylines, circles, rectangles, and text on the map. Covers all draw options, snapping, events, and styling."
 ---
 
 ## Draw Mode

--- a/docs/modes/10.difference-mode.mdx
+++ b/docs/modes/10.difference-mode.mdx
@@ -1,5 +1,6 @@
 ---
 title: Difference Mode ⭐
+description: "Subtract one polygon from another to create difference geometry. Pro feature with methods and events."
 ---
 
 ### Difference Mode ⭐

--- a/docs/modes/11.copy-mode.mdx
+++ b/docs/modes/11.copy-mode.mdx
@@ -1,5 +1,6 @@
 ---
 title: Copy Layer Mode ⭐
+description: "Copy existing layers on the map. Pro feature to duplicate geometry layers with their properties preserved."
 ---
 
 ### Copy Layer Mode ⭐

--- a/docs/modes/12.linesimplification-mode.mdx
+++ b/docs/modes/12.linesimplification-mode.mdx
@@ -1,5 +1,6 @@
 ---
 title: Line Simplification Mode ⭐
+description: "Simplify polyline and polygon geometry by reducing vertex count. Pro feature with configurable tolerance."
 ---
 
 ## Line Simplification Mode ⭐

--- a/docs/modes/13.customshapes-mode.mdx
+++ b/docs/modes/13.customshapes-mode.mdx
@@ -1,5 +1,6 @@
 ---
 title: Custom Shapes Mode ⭐
+description: "Draw predefined custom shapes like stars and other complex geometries. Pro feature."
 ---
 
 ## Custom Shapes Mode ⭐

--- a/docs/modes/14.lasso-select-mode.mdx
+++ b/docs/modes/14.lasso-select-mode.mdx
@@ -1,5 +1,6 @@
 ---
 title: Lasso Select Mode ⭐
+description: "Select multiple layers at once by drawing a freehand lasso selection area. Pro feature."
 ---
 
 ## Lasso Select Mode ⭐

--- a/docs/modes/15.freehand-mode.mdx
+++ b/docs/modes/15.freehand-mode.mdx
@@ -1,5 +1,6 @@
 ---
 title: Freehand Drawing Mode ⭐
+description: "Draw freehand polylines and polygons with smooth mouse or touch input. Pro feature."
 ---
 
 ## Freehand Drawing Mode ⭐

--- a/docs/modes/2.edit-mode.mdx
+++ b/docs/modes/2.edit-mode.mdx
@@ -1,5 +1,6 @@
 ---
 title: Edit Mode
+description: "Edit existing layers by moving vertices, adding or removing points, and configuring snapping. Covers global and per-layer edit options and events."
 ---
 
 ## Edit Mode

--- a/docs/modes/3.drag-mode.mdx
+++ b/docs/modes/3.drag-mode.mdx
@@ -1,5 +1,6 @@
 ---
 title: Drag Mode
+description: "Drag layers across the map. Enable globally or per-layer with sync options for coordinated layer movement."
 ---
 
 ## Drag Mode

--- a/docs/modes/4.removal-mode.md
+++ b/docs/modes/4.removal-mode.md
@@ -1,5 +1,6 @@
 ---
 title: Removal Mode
+description: "Remove layers from the map by clicking them. Enable globally with removal events and undo support."
 ---
 
 ## Removal Mode

--- a/docs/modes/5.cut-mode.mdx
+++ b/docs/modes/5.cut-mode.mdx
@@ -1,5 +1,6 @@
 ---
 title: Cut Mode
+description: "Cut holes in polygons and lines by drawing a cutting shape. Supports circle-shaped cutting. Covers cut mode methods, options, and events."
 ---
 
 ### Cut Mode

--- a/docs/modes/6.rotation-mode.mdx
+++ b/docs/modes/6.rotation-mode.mdx
@@ -1,5 +1,6 @@
 ---
 title: Rotation Mode
+description: "Rotate layers on the map. Enable globally or per-layer with configurable rotation angle and events."
 ---
 
 ### Rotation Mode

--- a/docs/modes/7.split-mode.mdx
+++ b/docs/modes/7.split-mode.mdx
@@ -1,5 +1,6 @@
 ---
 title: Split Mode ⭐
+description: "Split polylines and polygons by drawing a cutting line. Pro feature with split methods and events."
 ---
 
 ### Split Mode ⭐

--- a/docs/modes/8.scale-mode.mdx
+++ b/docs/modes/8.scale-mode.mdx
@@ -1,5 +1,6 @@
 ---
 title: Scale Mode ⭐
+description: "Scale layers with center or corner origin. Supports uniform and non-uniform scaling with keyboard modifiers. Pro feature."
 ---
 
 ### Scale Mode ⭐

--- a/docs/modes/9.union-mode.mdx
+++ b/docs/modes/9.union-mode.mdx
@@ -1,5 +1,6 @@
 ---
 title: Union Mode ⭐
+description: "Merge two polygon or multipolygon layers into one unified shape. Pro feature with union methods and events."
 ---
 
 ### Union Mode ⭐

--- a/docs/options/0.index.md
+++ b/docs/options/0.index.md
@@ -1,5 +1,6 @@
 ---
 title: "Options"
+description: "Global options for Leaflet-Geoman including snapping order, layer groups, panes, and keyboard shortcuts."
 ---
 
 ### Options

--- a/docs/options/1.snapping.md
+++ b/docs/options/1.snapping.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 title: "Snapping"
+description: "Configure vertex snapping for precision drawing and editing. Enable snapping globally, per-layer, or via toolbar button."
 ---
 ### Snapping
 

--- a/docs/options/2.pinning.mdx
+++ b/docs/options/2.pinning.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 2
 title: Pinning ⭐
+description: "Pin shared vertices together so editing one vertex moves all connected vertices. Pro feature."
 ---
 
 ### Pinning ⭐

--- a/docs/options/3.measurement.mdx
+++ b/docs/options/3.measurement.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 3
 title: Measurement ⭐
+description: "Display real-time measurements (area, length, radius) while drawing and editing layers. Pro feature with metric and imperial units."
 ---
 
 ### Measurement ⭐

--- a/docs/options/4.auto-tracing.mdx
+++ b/docs/options/4.auto-tracing.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 4
 title: AutoTracing ⭐
+description: "Automatically trace existing layer boundaries while drawing or cutting. Pro feature with configurable distance."
 ---
 
 ### AutoTracing ⭐

--- a/docs/options/5.performance.mdx
+++ b/docs/options/5.performance.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 5
 title: Performance
+description: "Optimize Leaflet-Geoman performance for maps with many layers. Includes marker limiting and viewport-based rendering."
 ---
 
 ### Performance

--- a/docs/options/6.snap-guides.mdx
+++ b/docs/options/6.snap-guides.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 6
 title: Snap Guides ⭐
+description: "Display alignment guides when moving vertices to help align with other features. Pro feature."
 ---
 
 ### Snap Guides ⭐

--- a/docs/options/7.geofencing.mdx
+++ b/docs/options/7.geofencing.mdx
@@ -1,5 +1,6 @@
 ---
 title: Geofencing ⭐
+description: "Enforce spatial constraints: prevent layer intersection and require containment within boundaries. Pro feature."
 ---
 
 ## Geofencing ⭐

--- a/docs/text-layer.md
+++ b/docs/text-layer.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 5
 title: "Text Layer"
+description: "Create, edit, and style text layers on the map. Covers text drawing options, programmatic creation, and text editing events."
 ---
 ### Text Layer
 

--- a/docs/toolbar.md
+++ b/docs/toolbar.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 2
 title: "Toolbar"
+description: "Add and configure the Leaflet-Geoman toolbar with drawing, editing, and custom control buttons. Covers all toolbar options and events."
 ---
 ### Leaflet-Geoman Toolbar
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -236,7 +236,6 @@
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.46.0.tgz",
       "integrity": "sha512-22SHEEVNjZfFWkFks3P6HilkR3rS7a6GjnCIqR22Zz4HNxdfT0FG+RE7efTcFVfLUkTTMQQybvaUcwMrHXYa7Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.46.0",
         "@algolia/requester-browser-xhr": "5.46.0",
@@ -362,7 +361,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2152,7 +2150,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2175,7 +2172,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2285,7 +2281,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -2707,7 +2702,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3642,7 +3636,6 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
       "integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/logger": "3.9.2",
@@ -4369,7 +4362,6 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -4699,7 +4691,6 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -5987,7 +5978,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.4.tgz",
       "integrity": "sha512-J7W30FTdfCxDDjmfRM+/JqLHBIyl7xUIp9kwK637FGmY7+mkSFSe6L4jpZzhj5QMfLssSDP4/i75AKkrdC7/Jw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -6339,7 +6329,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6413,7 +6402,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6459,7 +6447,6 @@
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.46.0.tgz",
       "integrity": "sha512-7ML6fa2K93FIfifG3GMWhDEwT5qQzPTmoHKCTvhzGEwdbQ4n0yYUWZlLYT75WllTGJCJtNUI0C1ybN4BCegqvg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.12.0",
         "@algolia/client-abtesting": "5.46.0",
@@ -6932,7 +6919,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7883,7 +7869,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -9257,7 +9242,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -11011,8 +10995,7 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -13750,7 +13733,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -14282,7 +14264,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -15186,7 +15167,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -15983,7 +15963,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -15996,7 +15975,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -16066,7 +16044,6 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
       "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -16095,7 +16072,6 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -17825,7 +17801,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -18036,8 +18011,7 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-fest": {
       "version": "2.19.0",
@@ -18100,7 +18074,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18451,7 +18424,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -18659,7 +18631,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
       "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -18935,7 +18906,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -19298,7 +19268,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/plugins/llm-txt-plugin.ts
+++ b/plugins/llm-txt-plugin.ts
@@ -4,15 +4,55 @@ import * as path from 'path';
 
 interface DocContent {
   title: string;
-  path: string;
+  description: string;
+  urlPath: string;
   content: string;
+  category: string;
 }
 
-function extractFrontmatter(content: string): { title: string; body: string } {
+// Map directory names to display category names
+const CATEGORY_NAMES: Record<string, string> = {
+  'getting-started': 'Getting Started',
+  'modes': 'Modes',
+  'options': 'Options',
+  'customize': 'Customization',
+  'changelog': 'Changelog',
+};
+
+// Map standalone files (by URL slug) to categories
+const STANDALONE_CATEGORIES: Record<string, string> = {
+  'toolbar': 'Toolbar',
+  'text-layer': 'Other Features',
+  'layer-groups': 'Other Features',
+  'utils': 'Other Features',
+  'screenshots': 'Other Features',
+  'lazy-loading': 'Other Features',
+  'keyboard': 'Other Features',
+};
+
+// Category display order
+const CATEGORY_ORDER = [
+  'Getting Started',
+  'Toolbar',
+  'Modes',
+  'Options',
+  'Customization',
+  'Other Features',
+  'Changelog',
+];
+
+function extractFrontmatter(content: string): {
+  title: string;
+  description: string;
+  slug: string;
+  body: string;
+} {
   const frontmatterRegex = /^---\s*\n([\s\S]*?)\n---\s*\n/;
   const match = content.match(frontmatterRegex);
 
   let title = '';
+  let description = '';
+  let slug = '';
   let body = content;
 
   if (match) {
@@ -20,6 +60,16 @@ function extractFrontmatter(content: string): { title: string; body: string } {
     const titleMatch = frontmatter.match(/title:\s*["']?([^"'\n]+)["']?/);
     if (titleMatch) {
       title = titleMatch[1].trim();
+    }
+    const descMatch = frontmatter.match(
+      /description:\s*["']?([^"'\n]+)["']?/
+    );
+    if (descMatch) {
+      description = descMatch[1].trim();
+    }
+    const slugMatch = frontmatter.match(/slug:\s*["']?([^"'\n]+)["']?/);
+    if (slugMatch) {
+      slug = slugMatch[1].trim();
     }
     body = content.slice(match[0].length);
   }
@@ -31,21 +81,97 @@ function extractFrontmatter(content: string): { title: string; body: string } {
     }
   }
 
-  return { title, body };
+  return { title, description, slug, body };
 }
 
 function stripMdxComponents(content: string): string {
+  // Remove import statements
   let cleaned = content.replace(/^import\s+.*$/gm, '');
 
+  // Remove self-closing JSX components: <Component />
   cleaned = cleaned.replace(/<[A-Z][a-zA-Z]*[^>]*\/>/g, '');
-  cleaned = cleaned.replace(/<[A-Z][a-zA-Z]*[^>]*>[\s\S]*?<\/[A-Z][a-zA-Z]*>/g, '');
 
+  // Remove JSX component blocks (including multiline): <Component>...</Component>
+  // Use a more robust approach - repeatedly strip innermost components
+  let prev = '';
+  while (prev !== cleaned) {
+    prev = cleaned;
+    cleaned = cleaned.replace(
+      /<([A-Z][a-zA-Z]*)[^>]*>[\s\S]*?<\/\1>/g,
+      ''
+    );
+  }
+
+  // Remove HTML image tags
+  cleaned = cleaned.replace(/<img[^>]*\/?>/gi, '');
+
+  // Remove markdown images (![alt](url))
+  cleaned = cleaned.replace(/!\[[^\]]*\]\([^)]+\)/g, '');
+
+  // Remove <details>/<summary> tags but keep inner content
+  cleaned = cleaned.replace(/<\/?details[^>]*>/gi, '');
+  cleaned = cleaned.replace(/<\/?summary[^>]*>/gi, '');
+
+  // Remove inline HTML div wrappers
+  cleaned = cleaned.replace(/<div[^>]*>/gi, '');
+  cleaned = cleaned.replace(/<\/div>/gi, '');
+
+  // Collapse multiple blank lines
   cleaned = cleaned.replace(/\n{3,}/g, '\n\n');
 
   return cleaned.trim();
 }
 
-function getAllMarkdownFiles(dir: string, baseDir: string = dir): DocContent[] {
+/**
+ * Strip a leading heading if it duplicates the title.
+ */
+function stripLeadingHeading(content: string, title: string): string {
+  const normalizedTitle = title.replace(/[⭐\s]+$/g, '').trim().toLowerCase();
+  return content.replace(/^(#{1,6})\s+(.+)\n*/, (match, _hashes, heading) => {
+    const normalizedHeading = heading.replace(/[⭐\s]+$/g, '').trim().toLowerCase();
+    return normalizedHeading === normalizedTitle ? '' : match;
+  });
+}
+
+function computeUrlPath(relativePath: string, slug: string): string {
+  if (slug) {
+    return slug.replace(/^\//, '');
+  }
+
+  return (
+    relativePath
+      .replace(/\\/g, '/')
+      .replace(/\.mdx?$/, '')
+      // Strip numeric prefixes: "12.utils" → "utils", "0.index" → "index"
+      .replace(/^\d+\./, '')
+      .replace(/\/\d+\./g, '/')
+      // Remove trailing "index"
+      .replace(/\/?index$/, '')
+  );
+}
+
+function getCategory(relativePath: string, urlPath: string): string {
+  const normalizedPath = relativePath.replace(/\\/g, '/');
+  const dir = normalizedPath.split('/')[0];
+
+  // Files in subdirectories get category from directory name
+  if (normalizedPath.includes('/') && CATEGORY_NAMES[dir]) {
+    return CATEGORY_NAMES[dir];
+  }
+
+  // Standalone files use the lookup map
+  const slug = urlPath.replace(/\/$/, '');
+  if (STANDALONE_CATEGORIES[slug]) {
+    return STANDALONE_CATEGORIES[slug];
+  }
+
+  return '';
+}
+
+function getAllMarkdownFiles(
+  dir: string,
+  baseDir: string = dir
+): DocContent[] {
   const docs: DocContent[] = [];
 
   if (!fs.existsSync(dir)) {
@@ -62,21 +188,19 @@ function getAllMarkdownFiles(dir: string, baseDir: string = dir): DocContent[] {
       docs.push(...getAllMarkdownFiles(fullPath, baseDir));
     } else if (item.endsWith('.md') || item.endsWith('.mdx')) {
       const content = fs.readFileSync(fullPath, 'utf-8');
-      const { title, body } = extractFrontmatter(content);
+      const { title, description, slug, body } = extractFrontmatter(content);
       const cleanedContent = stripMdxComponents(body);
 
       const relativePath = path.relative(baseDir, fullPath);
-      const urlPath = relativePath
-        .replace(/\\/g, '/')
-        .replace(/\.mdx?$/, '')
-        .replace(/index$/, '')
-        .replace(/^\d+-/, '')
-        .replace(/\/\d+-/g, '/');
+      const urlPath = computeUrlPath(relativePath, slug);
+      const category = getCategory(relativePath, urlPath);
 
       docs.push({
         title: title || path.basename(item, path.extname(item)),
-        path: urlPath,
+        description,
+        urlPath,
         content: cleanedContent,
+        category,
       });
     }
   }
@@ -84,58 +208,167 @@ function getAllMarkdownFiles(dir: string, baseDir: string = dir): DocContent[] {
   return docs;
 }
 
-function generateLlmTxt(docs: DocContent[], siteUrl: string, baseUrl: string): string {
-  const header = `# Leaflet-Geoman Documentation
+/**
+ * Generate spec-compliant llms.txt index file.
+ * Format: H1 title, blockquote summary, H2 category sections with links.
+ */
+function generateLlmsIndex(
+  docs: DocContent[],
+  siteUrl: string,
+  baseUrl: string
+): string {
+  const fullUrl = (urlPath: string) =>
+    urlPath ? `${siteUrl}${baseUrl}/${urlPath}` : `${siteUrl}${baseUrl}`;
 
-> This file contains all documentation in a format optimized for LLMs.
+  // Group docs by category
+  const grouped = new Map<string, DocContent[]>();
+  for (const doc of docs) {
+    if (!doc.category) continue; // skip intro page
+    if (!grouped.has(doc.category)) {
+      grouped.set(doc.category, []);
+    }
+    grouped.get(doc.category)!.push(doc);
+  }
+
+  let output = `# Leaflet-Geoman
+
+> Leaflet-Geoman is a Leaflet plugin for creating and editing geometry layers. It supports drawing, editing, dragging, cutting, rotating, splitting, scaling, measuring, snapping, and pinning markers, polygons, polylines, circles, rectangles, and more. Source: ${siteUrl}${baseUrl}
+
+`;
+
+  for (const categoryName of CATEGORY_ORDER) {
+    const categoryDocs = grouped.get(categoryName);
+    if (!categoryDocs || categoryDocs.length === 0) continue;
+
+    // Changelogs go in Optional section
+    if (categoryName === 'Changelog') {
+      output += `## Optional\n\n`;
+    } else {
+      output += `## ${categoryName}\n\n`;
+    }
+
+    for (const doc of categoryDocs) {
+      const desc = doc.description ? `: ${doc.description}` : '';
+      output += `- [${doc.title}](${fullUrl(doc.urlPath)})${desc}\n`;
+    }
+
+    output += '\n';
+  }
+
+  return output.trim() + '\n';
+}
+
+/**
+ * Generate llms-full.txt with complete documentation content.
+ */
+function generateLlmsFull(
+  docs: DocContent[],
+  siteUrl: string,
+  baseUrl: string
+): string {
+  const fullUrl = (urlPath: string) =>
+    urlPath ? `${siteUrl}${baseUrl}/${urlPath}` : `${siteUrl}${baseUrl}`;
+
+  let output = `# Leaflet-Geoman Documentation (Full)
+
+> Complete documentation for Leaflet-Geoman, a Leaflet plugin for creating and editing geometry layers.
 > Source: ${siteUrl}${baseUrl}
-
-## Table of Contents
-
-${docs.map((doc, i) => `${i + 1}. [${doc.title}](#${doc.title.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')})`).join('\n')}
+> Index: ${siteUrl}${baseUrl}/llms.txt
 
 ---
 
 `;
 
-  const content = docs
-    .map((doc) => {
-      return `## ${doc.title}
+  for (const doc of docs) {
+    output += `## ${doc.title}\n\n`;
+    if (doc.description) {
+      output += `> ${doc.description}\n\n`;
+    }
+    output += `**URL:** ${fullUrl(doc.urlPath)}\n\n`;
+    output += `${stripLeadingHeading(doc.content, doc.title)}\n\n`;
+    output += `---\n\n`;
+  }
 
-**URL:** ${siteUrl}${baseUrl}/${doc.path}
+  return output;
+}
 
-${doc.content}
+function generateAllFiles(
+  context: LoadContext,
+  outputDir: string,
+  options: { includeMdFiles: boolean }
+) {
+  const docsDir = path.join(context.siteDir, 'docs');
+  const docs = getAllMarkdownFiles(docsDir);
 
----
-`;
-    })
-    .join('\n');
+  docs.sort((a, b) => a.urlPath.localeCompare(b.urlPath));
 
-  return header + content;
+  const siteUrl = context.siteConfig.url;
+  const baseUrl = context.siteConfig.baseUrl.replace(/\/$/, '');
+
+  // 1. Generate spec-compliant llms.txt index
+  const llmsIndex = generateLlmsIndex(docs, siteUrl, baseUrl);
+  fs.writeFileSync(path.join(outputDir, 'llms.txt'), llmsIndex, 'utf-8');
+
+  // 2. Generate llms-full.txt content dump
+  const llmsFull = generateLlmsFull(docs, siteUrl, baseUrl);
+  fs.writeFileSync(path.join(outputDir, 'llms-full.txt'), llmsFull, 'utf-8');
+
+  // 3. Write individual .md files for each doc page
+  if (options.includeMdFiles) {
+    for (const doc of docs) {
+      if (!doc.urlPath) continue;
+
+      const mdOutputPath = path.join(outputDir, doc.urlPath + '.md');
+      fs.mkdirSync(path.dirname(mdOutputPath), { recursive: true });
+
+      const bodyContent = stripLeadingHeading(doc.content, doc.title);
+      let mdContent = `# ${doc.title}\n\n`;
+      if (doc.description) {
+        mdContent += `> ${doc.description}\n\n`;
+      }
+      mdContent += bodyContent + '\n';
+
+      fs.writeFileSync(mdOutputPath, mdContent, 'utf-8');
+    }
+  }
+
+  return docs.length;
 }
 
 export default function llmTxtPlugin(context: LoadContext): Plugin {
-  const generateAndSaveLlmTxt = (outputDir: string) => {
-    const docsDir = path.join(context.siteDir, 'docs');
-    const docs = getAllMarkdownFiles(docsDir);
-
-    docs.sort((a, b) => a.path.localeCompare(b.path));
-
-    const llmTxt = generateLlmTxt(
-      docs,
-      context.siteConfig.url,
-      context.siteConfig.baseUrl.replace(/\/$/, '')
-    );
-
-    const outputPath = path.join(outputDir, 'llms.txt');
-    fs.writeFileSync(outputPath, llmTxt, 'utf-8');
-    console.log(`Generated llms.txt at ${outputPath}`);
-  };
-
   return {
     name: 'llm-txt-plugin',
+
+    // Generate to static/ so files are served during dev
+    async loadContent() {
+      const staticDir = path.join(context.siteDir, 'static');
+      generateAllFiles(context, staticDir, { includeMdFiles: false });
+      console.log('[llm-txt] Generated llms.txt and llms-full.txt in static/');
+    },
+
+    injectHtmlTags() {
+      return {
+        headTags: [
+          {
+            tagName: 'link',
+            attributes: {
+              rel: 'alternate',
+              type: 'text/markdown',
+              href: `${context.siteConfig.baseUrl}llms.txt`,
+            },
+          },
+        ],
+      };
+    },
+
+    // Generate full set (including per-page .md files) to build output
     async postBuild(props) {
-      generateAndSaveLlmTxt(props.outDir);
+      const count = generateAllFiles(context, props.outDir, {
+        includeMdFiles: true,
+      });
+      console.log(
+        `[llm-txt] Generated llms.txt, llms-full.txt, and ${count} .md files in build/`
+      );
     },
   };
 }

--- a/src/components/CopyAsMarkdown/index.tsx
+++ b/src/components/CopyAsMarkdown/index.tsx
@@ -10,17 +10,15 @@ export default function CopyAsMarkdown({ className }: CopyAsMarkdownProps): JSX.
 
   const handleCopy = useCallback(async () => {
     try {
-      // Get the current page's markdown source URL
-      const editUrl = document.querySelector<HTMLAnchorElement>('a[href*="github.com"][href*="/edit/"]');
+      // Try fetching the local .md file generated during build
+      const currentPath = window.location.pathname.replace(/\/$/, '');
+      const mdUrl = currentPath + '.md';
 
-      if (editUrl) {
-        // Convert edit URL to raw content URL
-        const rawUrl = editUrl.href
-          .replace('github.com', 'raw.githubusercontent.com')
-          .replace('/edit/', '/');
-
-        const response = await fetch(rawUrl);
-        if (response.ok) {
+      const response = await fetch(mdUrl);
+      if (response.ok) {
+        const contentType = response.headers.get('content-type') || '';
+        // Verify we got markdown, not an HTML 404 page
+        if (!contentType.includes('text/html')) {
           const markdown = await response.text();
           await navigator.clipboard.writeText(markdown);
           setCopied(true);


### PR DESCRIPTION
## Summary

Makes the Leaflet-Geoman documentation best-in-class for LLM and agent consumption, following the [llms.txt specification](https://llmstxt.org/) and inspired by Resend's documentation approach.

## Changes

- **llms.txt**: Spec-compliant index file with categorized links and descriptions for easy LLM navigation
- **llms-full.txt**: Complete documentation content in a single file for comprehensive context
- **Per-page .md files**: Each doc accessible as clean markdown at `{url}.md` for seamless content extraction
- **Meta tag injection**: Auto-discovery `<link rel="alternate" type="text/markdown">` tag on every page
- **Updated CopyAsMarkdown**: Now fetches local clean markdown instead of GitHub raw URLs
- **Description frontmatter**: All 38 docs now include one-line descriptions for indexing and SEO

## Testing

- Build succeeds: `npm run build` generates llms.txt, llms-full.txt, and 38 individual .md files
- Dev mode works: Files are served from `static/` during `npm start` at `http://localhost:3001/docs/leaflet/llms.txt`
- Meta tags present: All pages include the `<link rel="alternate">` tag for agent discovery
- Copy button works: Fetches local .md files with fallback to visible content

🤖 Generated with [Claude Code](https://claude.com/claude-code)