### PR TITLE
Add lead capture CTAs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 engine-strict=true
 @geoman-io:registry=https://npm.geoman.io/
+//npm.geoman.io/:_authToken=${NPM_TOKEN_GEOMAN}

--- a/docs/getting-started/pro-version.md
+++ b/docs/getting-started/pro-version.md
@@ -1,7 +1,9 @@
 ---
 sidebar_position: 2
-title: "Pro Version"
+title: "Pro Version ⭐"
 ---
+import ProCallout from '@site/src/components/ProCallout';
+
 ## Installation
 
 Add the following content to `.npmrc` in your project root
@@ -12,7 +14,7 @@ Add the following content to `.npmrc` in your project root
 ```
 
 Replace `<YOUR LICENSE KEY>` with your license key.  
-_Don't have a license key yet? [Purchase one here](https://geoman.io/pricing)._
+_Don't have a license key yet? <a href="https://geoman.io/pricing" className="pro-cta-link">Purchase one here</a>._
 
 #### Install via npm
 
@@ -93,3 +95,5 @@ map.on("pm:create", (e) => {
   L.PM.reInitLayer(e.layer);
 });
 ```
+
+<ProCallout />

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ Features _not_ available in the free version are marked with a star (⭐).
 **Get Started**
 
 - [🆓 Install Free Version](/getting-started/free-version)
-- [⭐ Install Pro Version](/getting-started/pro-version)
+- <a href="/docs/leaflet/getting-started/pro-version" className="pro-cta-link">⭐ Install Pro Version</a>
 
 **Configuration and Setup**
 

--- a/docs/modes/10.difference-mode.mdx
+++ b/docs/modes/10.difference-mode.mdx
@@ -35,5 +35,8 @@ The following events are available on a map instance:
 ## Example
 
 import Difference from '@site/src/components/examples/Difference';
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
 
 <Difference />
+
+<IntegrationHelpCallout />

--- a/docs/modes/11.copy-mode.mdx
+++ b/docs/modes/11.copy-mode.mdx
@@ -47,5 +47,8 @@ map.pm.addControls({
 ```
 
 import Copy from '@site/src/components/examples/Copy';
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
 
 <Copy />
+
+<IntegrationHelpCallout />

--- a/docs/modes/12.linesimplification-mode.mdx
+++ b/docs/modes/12.linesimplification-mode.mdx
@@ -45,5 +45,8 @@ map.pm.addControls({
 ## Examples
 
 import LineSimplification from '@site/src/components/examples/LineSimplification';
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
 
 <LineSimplification />
+
+<IntegrationHelpCallout />

--- a/docs/modes/13.customshapes-mode.mdx
+++ b/docs/modes/13.customshapes-mode.mdx
@@ -124,6 +124,7 @@ This will create a circle with a 1000-unit radius for each point in the GeoJSON.
 ## Demo Examples
 
 import CustomShapes from '@site/src/components/examples/CustomShapes';
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
 
 Draw a custom shape with a predefined GeoJSON shape:
 <CustomShapes />
@@ -131,3 +132,5 @@ Draw a custom shape with a predefined GeoJSON shape:
 Add a custom shape to the library and to the toolbar:
 
 <CustomShapes init='toolbar' />
+
+<IntegrationHelpCallout />

--- a/docs/modes/14.lasso-select-mode.mdx
+++ b/docs/modes/14.lasso-select-mode.mdx
@@ -136,5 +136,8 @@ map.pm.addControls({
 - Lasso Select Mode works with various layer types including markers, circles, polygons, polylines, and rectangles.
 
 import LassoSelect from '@site/src/components/examples/LassoSelect';
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
 
 <LassoSelect />
+
+<IntegrationHelpCallout />

--- a/docs/modes/15.freehand-mode.mdx
+++ b/docs/modes/15.freehand-mode.mdx
@@ -131,3 +131,7 @@ Polygon Drawing:
 
 <FreehandDrawing fill={true}/>
 
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
+
+<IntegrationHelpCallout />
+

--- a/docs/modes/7.split-mode.mdx
+++ b/docs/modes/7.split-mode.mdx
@@ -48,5 +48,8 @@ The following events are available on a map instance:
 ## Example
 
 import Split from '@site/src/components/examples/Split';
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
 
 <Split />
+
+<IntegrationHelpCallout />

--- a/docs/modes/8.scale-mode.mdx
+++ b/docs/modes/8.scale-mode.mdx
@@ -60,5 +60,8 @@ The following events are available on a map instance:
 ## Example
 
 import Scale from '@site/src/components/examples/Scale';
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
 
 <Scale />
+
+<IntegrationHelpCallout />

--- a/docs/modes/9.union-mode.mdx
+++ b/docs/modes/9.union-mode.mdx
@@ -35,5 +35,8 @@ The following events are available on a map instance:
 ## Example
 
 import Union from '@site/src/components/examples/Union';
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
 
 <Union />
+
+<IntegrationHelpCallout />

--- a/docs/options/2.pinning.mdx
+++ b/docs/options/2.pinning.mdx
@@ -40,6 +40,7 @@ map.pm.addControls({
 ## Example
 
 import Pinning from '@site/src/components/examples/Pinning';
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
 
 Editing with Pinning enabled (try dragging the intersecting markers):
 
@@ -48,3 +49,5 @@ Editing with Pinning enabled (try dragging the intersecting markers):
 Same example with Pinning disabled:
 
 <Pinning pinning={false} />
+
+<IntegrationHelpCallout />

--- a/docs/options/3.measurement.mdx
+++ b/docs/options/3.measurement.mdx
@@ -47,3 +47,7 @@ Measurement enabled with metric display format:
 
 Measurement enabled with imperial display format:
 <Measurement displayFormat="imperial" />
+
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
+
+<IntegrationHelpCallout />

--- a/docs/options/4.auto-tracing.mdx
+++ b/docs/options/4.auto-tracing.mdx
@@ -35,3 +35,7 @@ import AutoTracing from '@site/src/components/examples/AutoTracing';
 
 AutoTracing enabled:
 <AutoTracing />
+
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
+
+<IntegrationHelpCallout />

--- a/docs/options/5.performance.mdx
+++ b/docs/options/5.performance.mdx
@@ -47,3 +47,7 @@ Performance improvements enabled with all features:
 }
 ```
 <Performance limitMarkersToZoom={15} limitMarkersToClick={true} limitMarkersToViewPort={true} limitMarkersToCount={10}/>
+
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
+
+<IntegrationHelpCallout />

--- a/docs/options/6.snap-guides.mdx
+++ b/docs/options/6.snap-guides.mdx
@@ -59,3 +59,7 @@ SnapGuides enabled with default angles of `snapGuidesAngles={[45,60,90]}`:
 
 SnapGuides enabled with default angles of `snapGuidesAngles={[15,30,45,60,75,90]}`:
 <SnapGuides angles={[15,30,45,60,75,90]}/>
+
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
+
+<IntegrationHelpCallout />

--- a/docs/options/7.geofencing.mdx
+++ b/docs/options/7.geofencing.mdx
@@ -136,3 +136,7 @@ map.pm.setGlobalOptions({
 In this demo, the preventIntersection option is enabled:
 
 <Geofencing preventIntersection={true}/>
+
+import IntegrationHelpCallout from '@site/src/components/IntegrationHelpCallout';
+
+<IntegrationHelpCallout />

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -29,13 +29,20 @@ const config: Config = {
     defaultLocale: 'en',
     locales: ['en'],
   },
+  stylesheets: [
+    'https://geoman.io/embed/docs-lead-capture.css',
+  ],
   scripts: [
     {
       src: 'https://umami.parap.ly/script.js',
       'data-website-id': 'bc78fba3-4928-4efa-9923-03048345048e',
       defer: true,
       async: true,
-    }
+    },
+    {
+      src: 'https://geoman.io/embed/docs-lead-capture.js',
+      defer: true,
+    },
   ],
   presets: [
     [

--- a/package-lock.json
+++ b/package-lock.json
@@ -236,7 +236,6 @@
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.46.0.tgz",
       "integrity": "sha512-22SHEEVNjZfFWkFks3P6HilkR3rS7a6GjnCIqR22Zz4HNxdfT0FG+RE7efTcFVfLUkTTMQQybvaUcwMrHXYa7Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.46.0",
         "@algolia/requester-browser-xhr": "5.46.0",
@@ -362,7 +361,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2152,7 +2150,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2175,7 +2172,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2285,7 +2281,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -2707,7 +2702,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3642,7 +3636,6 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
       "integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/logger": "3.9.2",
@@ -4369,7 +4362,6 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -4699,7 +4691,6 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -5987,7 +5978,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.4.tgz",
       "integrity": "sha512-J7W30FTdfCxDDjmfRM+/JqLHBIyl7xUIp9kwK637FGmY7+mkSFSe6L4jpZzhj5QMfLssSDP4/i75AKkrdC7/Jw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -6339,7 +6329,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6413,7 +6402,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6459,7 +6447,6 @@
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.46.0.tgz",
       "integrity": "sha512-7ML6fa2K93FIfifG3GMWhDEwT5qQzPTmoHKCTvhzGEwdbQ4n0yYUWZlLYT75WllTGJCJtNUI0C1ybN4BCegqvg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.12.0",
         "@algolia/client-abtesting": "5.46.0",
@@ -6932,7 +6919,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7883,7 +7869,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -9257,7 +9242,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -11011,8 +10995,7 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -13750,7 +13733,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -14282,7 +14264,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -15186,7 +15167,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -15983,7 +15963,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -15996,7 +15975,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -16066,7 +16044,6 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
       "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -16095,7 +16072,6 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -17825,7 +17801,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -18036,8 +18011,7 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-fest": {
       "version": "2.19.0",
@@ -18100,7 +18074,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18451,7 +18424,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -18659,7 +18631,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
       "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -18935,7 +18906,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -19298,7 +19268,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/IntegrationHelpCallout.js
+++ b/src/components/IntegrationHelpCallout.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function IntegrationHelpCallout() {
+  return (
+    <div className="docs-help-callout">
+      <p>
+        Building something complex?
+        Our team can help with architecture and integration.{' '}
+        <a href="mailto:sales@geoman.io?subject=Geoman%20Integration%20Help" className="consultation-link">
+          Get in touch →
+        </a>
+      </p>
+    </div>
+  );
+}

--- a/src/components/ProCallout.js
+++ b/src/components/ProCallout.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function ProCallout() {
+  return (
+    <div className="docs-pro-callout">
+      <p>
+        Need help evaluating Pro for your team?{' '}
+        <a href="mailto:sales@geoman.io?subject=Geoman%20Pro%20Consultation" className="consultation-link">
+          Book a free 15-minute consultation →
+        </a>
+      </p>
+    </div>
+  );
+}

--- a/src/components/SidebarSignup.js
+++ b/src/components/SidebarSignup.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default function SidebarSignup() {
+  return (
+    <div className="docs-signup-sidebar">
+      <h4>Stay Updated</h4>
+      <p>Get changelog updates and Geoman tips.</p>
+      <form className="geoman-signup" data-placement="sidebar">
+        <input type="email" name="email" placeholder="you@company.com" required />
+        <input
+          type="text"
+          name="_hp"
+          style={{ position: 'absolute', left: '-9999px' }}
+          tabIndex={-1}
+          autoComplete="off"
+        />
+        <button type="submit">Subscribe</button>
+      </form>
+    </div>
+  );
+}

--- a/src/theme/DocItem/Footer/index.tsx
+++ b/src/theme/DocItem/Footer/index.tsx
@@ -1,0 +1,30 @@
+import React, {type ReactNode} from 'react';
+import Footer from '@theme-original/DocItem/Footer';
+import type FooterType from '@theme/DocItem/Footer';
+import type {WrapperProps} from '@docusaurus/types';
+
+type Props = WrapperProps<typeof FooterType>;
+
+export default function FooterWrapper(props: Props): ReactNode {
+  return (
+    <>
+      <div className="docs-signup-footer">
+        <h4>Found this helpful?</h4>
+        <p>Subscribe for changelog updates, tips, and new feature announcements.</p>
+        <form className="geoman-signup" data-placement="page-footer">
+          <input type="email" name="email" placeholder="you@company.com" required />
+          <input type="text" name="name" placeholder="Name (optional)" />
+          <input
+            type="text"
+            name="_hp"
+            style={{ position: 'absolute', left: '-9999px' }}
+            tabIndex={-1}
+            autoComplete="off"
+          />
+          <button type="submit">Subscribe</button>
+        </form>
+      </div>
+      <Footer {...props} />
+    </>
+  );
+}

--- a/src/theme/DocSidebar/Desktop/Content/index.tsx
+++ b/src/theme/DocSidebar/Desktop/Content/index.tsx
@@ -1,0 +1,16 @@
+import React, {type ReactNode} from 'react';
+import Content from '@theme-original/DocSidebar/Desktop/Content';
+import type ContentType from '@theme/DocSidebar/Desktop/Content';
+import type {WrapperProps} from '@docusaurus/types';
+import SidebarSignup from '@site/src/components/SidebarSignup';
+
+type Props = WrapperProps<typeof ContentType>;
+
+export default function ContentWrapper(props: Props): ReactNode {
+  return (
+    <>
+      <Content {...props} />
+      <SidebarSignup />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Adds lead capture touchpoints throughout the docs:
- Sidebar email signup form (every page)
- End-of-page email signup form (every page)
- Pro consultation callout (Pro Version page)
- Integration help callout (15 Pro/advanced pages + Performance)
- Pro CTA link tracking for analytics

## Implementation

- Added `docs-lead-capture.css` and `docs-lead-capture.js` from geoman.io to global config
- Created 3 reusable components: SidebarSignup, ProCallout, IntegrationHelpCallout
- Swizzled DocSidebar and DocItem/Footer wrappers to inject forms
- Updated .npmrc with registry auth token

All forms POST to `https://geoman.io/api/leads` with Umami tracking (newsletter-signup, consultation-click, pro-cta-click events).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>